### PR TITLE
fix: update pre-start script to use ruby-3.2 runtime env

### DIFF
--- a/jobs/uaa-registrar/templates/pre-start.erb
+++ b/jobs/uaa-registrar/templates/pre-start.erb
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source /var/vcap/packages/ruby-3.1/bosh/runtime.env
+source /var/vcap/packages/ruby-3.2/bosh/runtime.env
 export BUNDLE_GEMFILE=$(ls /var/vcap/data/packages/uaac/*/cf-uaac/Gemfile)
 export PATH=${PATH}:/var/vcap/packages/uaac/bin
 export HOME=/var/vcap/data/uaa-registrar/


### PR DESCRIPTION
   The pre-start script was still sourcing ruby-3.1/bosh/runtime.env
   causing 'No such file or directory' errors after the ruby-3.1 to
   ruby-3.2 migration.